### PR TITLE
fix sticky-footer css trick

### DIFF
--- a/src/lib/plugin/ng-bootstrap/tour-step-template.component.ts
+++ b/src/lib/plugin/ng-bootstrap/tour-step-template.component.ts
@@ -5,7 +5,6 @@ import { Component, TemplateRef, ViewChild, AfterViewInit, ViewEncapsulation } f
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'tour-step-template',
-  styles: ['body { max-height: 100vh; }'],
   template: `
     <template #tourStep let-step="step">
       <p class="tour-step-content">{{step?.content}}</p>


### PR DESCRIPTION
I don't understand the meaning of `max-height: 100vh` in `body` element, so i made this pull request to trying remove this line which will fix https://github.com/isaacplmann/ng2-tour/issues/21