### PR TITLE
Add options to TourService to disable hotkeys

### DIFF
--- a/ngx-tour-core/src/tour-hotkey-listener.component.ts
+++ b/ngx-tour-core/src/tour-hotkey-listener.component.ts
@@ -14,21 +14,26 @@ export class TourHotkeyListenerComponent {
    */
   @HostListener('window:keydown.Escape')
   public onEscapeKey(event: KeyboardEvent): void {
-    if (this.tourService.getStatus() === TourState.ON) {
+    if (this.tourService.getStatus() === TourState.ON
+      && this.tourService.isHotkeysEnanbled()) {
       this.tourService.end();
     }
   }
 
   @HostListener('window:keydown.ArrowRight')
   public onArrowRightKey(event: KeyboardEvent): void {
-    if (this.tourService.getStatus() === TourState.ON && this.tourService.hasNext(this.tourService.currentStep)) {
+    if (this.tourService.getStatus() === TourState.ON
+      && this.tourService.hasNext(this.tourService.currentStep)
+      && this.tourService.isHotkeysEnanbled()) {
       this.tourService.next();
     }
   }
 
   @HostListener('window:keydown.ArrowLeft')
   public onArrowLeftKey(event: KeyboardEvent): void {
-    if (this.tourService.getStatus() === TourState.ON && this.tourService.hasPrev(this.tourService.currentStep)) {
+    if (this.tourService.getStatus() === TourState.ON
+      && this.tourService.hasPrev(this.tourService.currentStep)
+      && this.tourService.isHotkeysEnanbled()) {
       this.tourService.prev();
     }
   }

--- a/ngx-tour-core/src/tour.service.ts
+++ b/ngx-tour-core/src/tour.service.ts
@@ -57,13 +57,15 @@ export class TourService<T extends IStepOption = IStepOption> {
 
   public anchors: { [anchorId: string]: TourAnchorDirective } = {};
   private status: TourState = TourState.OFF;
+  private isHotKeysEnabled = false;
 
   constructor(private router: Router) { }
 
-  public initialize(steps: T[], stepDefaults?: T): void {
+  public initialize(steps: T[], stepDefaults?: T, isHotkeysEnabled = true): void {
     if (steps && steps.length > 0) {
       this.status = TourState.OFF;
       this.steps = steps.map(step => Object.assign({}, stepDefaults, step));
+      this.isHotKeysEnabled = isHotkeysEnabled;
       this.initialize$.next(this.steps);
     }
   }
@@ -165,6 +167,10 @@ export class TourService<T extends IStepOption = IStepOption> {
 
   public getStatus(): TourState {
     return this.status;
+  }
+
+  public isHotkeysEnanbled(): boolean {
+    return this.isHotKeysEnabled;
   }
 
   private goToStep(step: T): void {

--- a/ngx-tour-ngx-bootstrap/package.json
+++ b/ngx-tour-ngx-bootstrap/package.json
@@ -4,10 +4,8 @@
   "repository": "https://github.com/isaacplmann/ngx-tour.git",
   "author": "Rachel Yordán <rachelyordan@gmail.com>",
   "license": "MIT",
-  "peerDependencies": {
-    "ngx-bootstrap": "^1.9.3"
-  },
   "dependencies": {
+    "ngx-bootstrap": "^1.9.3",
     "ngx-tour-core": "^1.0.0",
     "withinviewport": "^2.0.0"
   }


### PR DESCRIPTION
An option `isHotkeysEnabled` with a default value of `true` has been added to the initialize method of the TourService. The TourHotkeyListenerComponent checks the value of isHotkeysEnabled() to determine if it should react to a hotkey being pressed.

In addition I needed to move the `ngx-bootstrap` peerDependency to the list of normal dependencies to get the project to build.