### PR TITLE
fix: NavigationStart only hide currentStep if route is specified eg. routing used

### DIFF
--- a/projects/ngx-tour-core/src/lib/tour.service.ts
+++ b/projects/ngx-tour-core/src/lib/tour.service.ts
@@ -95,7 +95,7 @@ export class TourService<T extends IStepOption = IStepOption> {
     this.router.events
       .pipe(filter(event => event instanceof NavigationStart), first())
       .subscribe(() => {
-        if (this.currentStep) {
+        if (this.currentStep && this.currentStep.hasOwnProperty('route')) {
           this.hideStep(this.currentStep);
         }
       });
@@ -237,8 +237,8 @@ export class TourService<T extends IStepOption = IStepOption> {
     this.showStep(this.currentStep);
     this.router.events
       .pipe(filter(event => event instanceof NavigationStart), first())
-      .subscribe(() => {
-        if (this.currentStep) {
+      .subscribe((event) => {
+        if (this.currentStep && this.currentStep.hasOwnProperty('route')) {
           this.hideStep(this.currentStep);
         }
       });


### PR DESCRIPTION
Dear isaac 

**Introduction**
We had a issue with the altered code, represeting a call to the hide function if any NavigationStart event happens. We are using some advanced routing mechanism, where the user will trigger interactively a router change but effectively he will stay on the same screen.

**Issue description**
The current implementation will hide the currentStep no matter if a custom router url per step is defined or not. this causing the tour to end, because we do not have any custom route defined for the following step.

**Issue solution**
The PR does only contain a little check for the property "route": this property will be set if any routing is used by the tourSteps and/or by the "stepDefaults". If it is being used, the mechanism will work as before. If there is no route property present (and therefore no handling required), it will just skip the hideStep call.

**Testing**
I've used the integrated demo/documentation pages and tested all of the modules. I had complete success with all modules, there were no sideeffect I've noticed.

Thanks for integrating the PR!
If you have any questions feel free to ask.

Greetings
Chris from enersis