### PR TITLE
Fix compatibility with Ivy rendering in Angular 8

### DIFF
--- a/projects/ngx-tour-md-menu/src/lib/tour-step-template.component.ts
+++ b/projects/ngx-tour-md-menu/src/lib/tour-step-template.component.ts
@@ -40,7 +40,6 @@ import {NgxmTourService} from './ngx-md-menu-tour.service';
 export class TourStepTemplateComponent extends TourHotkeyListenerComponent implements AfterViewInit {
   @ViewChild(MatMenu) public tourStep: MatMenu;
 
-  @Input()
   @ContentChild(TemplateRef)
   public stepTemplate: TemplateRef<{ step: IStepOption }>;
 

--- a/projects/ngx-tour-ng-bootstrap/src/lib/tour-step-template.component.ts
+++ b/projects/ngx-tour-ng-bootstrap/src/lib/tour-step-template.component.ts
@@ -20,7 +20,6 @@ import { NgbTourService } from './ng-bootstrap-tour.service';
 export class TourStepTemplateComponent extends TourHotkeyListenerComponent implements AfterContentInit {
   @ViewChild('tourStep', { read: TemplateRef }) public defaultTourStepTemplate: TemplateRef<any>;
 
-  @Input()
   @ContentChild(TemplateRef)
   public stepTemplate: TemplateRef<{ step: IStepOption }>;
 

--- a/projects/ngx-tour-ngx-bootstrap/src/lib/tour-step-template.component.ts
+++ b/projects/ngx-tour-ngx-bootstrap/src/lib/tour-step-template.component.ts
@@ -21,7 +21,6 @@ import { TourStepTemplateService } from './tour-step-template.service';
 export class TourStepTemplateComponent extends TourHotkeyListenerComponent implements AfterContentInit {
   @ViewChild('tourStep', { read: TemplateRef }) public defaultTourStepTemplate: TemplateRef<any>;
 
-  @Input()
   @ContentChild(TemplateRef)
   public stepTemplate: TemplateRef<{ step: IStepOption }>;
 

--- a/projects/ngx-tour-ngx-popper/src/lib/tour-step-template.component.ts
+++ b/projects/ngx-tour-ngx-popper/src/lib/tour-step-template.component.ts
@@ -26,7 +26,6 @@ import { TourStepTemplateService } from './tour-step-template.service';
 export class TourStepTemplateComponent extends TourHotkeyListenerComponent implements AfterViewInit, AfterContentInit {
   @ViewChild(PopperContent) public popperContent: PopperContent;
 
-  @Input()
   @ContentChild(TemplateRef)
   public stepTemplate: TemplateRef<{step: IStepOption}>;
 


### PR DESCRIPTION
Hello,
The PR is to fix an error when compiling with the new Ivy rendering. The error was : 
**ERROR in Cannot combine @Input decorators with query decorators**

This mean that a component can't have an attribut with both Input decorator and one of the query decorators (@ContentChild, @ContentChildren, @ViewChild, @ViewChildren, @Query).

This is a nonsense to have both decorator in the same attribut and I think the good ones to keep are the query decorator because this should be the most use technique. 
A solution to keep both decorator would be to create 2 attribut.  

See :  [https://stackoverflow.com/questions/56457566/cannot-combine-input-decorators-with-query-decorators-using-ivy](url)

I'm new to the PR in Github, don't hesitate to tell me if something is wrong or missing. 