### PR TITLE
support ng-bootstrap 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@angular/platform-browser": "^8.2.11",
     "@angular/platform-browser-dynamic": "^8.2.11",
     "@angular/router": "^8.2.11",
-    "@ng-bootstrap/ng-bootstrap": "^4.0.0",
+    "@ng-bootstrap/ng-bootstrap": "^5.1.4",
     "core-js": "^2.5.7",
     "ngx-bootstrap": "^5.2.0",
     "ngx-popper": "^2.7.1",

--- a/projects/ngx-tour-console/src/lib/console.module.ts
+++ b/projects/ngx-tour-console/src/lib/console.module.ts
@@ -10,7 +10,7 @@ export { TourAnchorConsoleDirective, TourService };
 @NgModule({
   declarations: [TourAnchorConsoleDirective],
   exports: [TourAnchorConsoleDirective, TourHotkeyListenerComponent],
-  imports: [TourModule, CommonModule, NgbPopoverModule.forRoot()],
+  imports: [TourModule, CommonModule, NgbPopoverModule],
 })
 export class TourConsoleModule {
   public static forRoot(): ModuleWithProviders {

--- a/projects/ngx-tour-ng-bootstrap/package.json
+++ b/projects/ngx-tour-ng-bootstrap/package.json
@@ -7,7 +7,7 @@
   "peerDependencies": {
     "@angular/common": ">=7.0.0 <9.0.0",
     "@angular/core": ">=7.0.0 <9.0.0",
-    "@ng-bootstrap/ng-bootstrap": "^4.0.0",
+    "@ng-bootstrap/ng-bootstrap": ">=5.0.0",
     "ngx-tour-core": "^4.1.1"
   },
   "dependencies": {

--- a/projects/ngx-tour-ng-bootstrap/src/lib/ng-bootstrap-tour.service.ts
+++ b/projects/ngx-tour-ng-bootstrap/src/lib/ng-bootstrap-tour.service.ts
@@ -3,5 +3,7 @@ import { TourService } from 'ngx-tour-core';
 
 import { INgbStepOption } from './step-option.interface';
 
-@Injectable()
+@Injectable({
+    providedIn: 'root',
+  })
 export class NgbTourService extends TourService<INgbStepOption> {}

--- a/projects/ngx-tour-ng-bootstrap/src/lib/ng-bootstrap.module.ts
+++ b/projects/ngx-tour-ng-bootstrap/src/lib/ng-bootstrap.module.ts
@@ -13,7 +13,7 @@ export { TourAnchorNgBootstrapDirective, TourAnchorNgBootstrapPopoverDirective, 
 @NgModule({
   declarations: [TourAnchorNgBootstrapDirective, TourAnchorNgBootstrapPopoverDirective, TourStepTemplateComponent],
   exports: [TourAnchorNgBootstrapDirective, TourAnchorNgBootstrapPopoverDirective, TourStepTemplateComponent],
-  imports: [CommonModule, NgbPopoverModule.forRoot()],
+  imports: [CommonModule, NgbPopoverModule],
 })
 export class TourNgBootstrapModule {
   public static forRoot(): ModuleWithProviders {

--- a/projects/ngx-tour-ng-bootstrap/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-tour-ng-bootstrap/src/lib/tour-anchor.directive.ts
@@ -26,7 +26,8 @@ export class TourAnchorNgBootstrapDirective implements OnInit, OnDestroy, TourAn
     private element: ElementRef,
     @Host() private popoverDirective: TourAnchorNgBootstrapPopoverDirective,
   ) {
-
+    this.popoverDirective.autoClose = false;
+    this.popoverDirective.triggers = '';
     this.popoverDirective.toggle = () => { };
   }
 


### PR DESCRIPTION
fix for #187 support for ng-bootstrap 5 + made sure that NgbTourService is only instantiated once. Also a fix for #180 'Cannot read property 'step' of undefined' clicking outside the popup doesn't trigger `tourService.end()` because the ngxBootstrap version doesn't autoClose I just set autoClose to false. If you want to support autoClose then something like this will support autoClose:

```
this.popupHideSubscription = this.popoverDirective.hidden.pipe(
    .subscribe(() => {
        this.tourService.end();
   });
```