### PR TITLE
Support ngx-bootstrap 5.5.0+ by changing import (fix #202)

### DIFF
--- a/projects/ngx-tour-ngx-bootstrap/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-tour-ngx-bootstrap/src/lib/tour-anchor.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, Host, HostBinding, Input, OnDestroy, OnInit } from '@angular/core';
-import { PopoverDirective } from 'ngx-bootstrap';
+import { PopoverDirective } from 'ngx-bootstrap/popover';
 import { TourAnchorDirective } from 'ngx-tour-core';
 import { INgxbStepOption as IStepOption } from './step-option.interface';
 import withinviewport from 'withinviewport';


### PR DESCRIPTION
Adds support for ngx-bootstrap 5.5.0 or higher by fixing #202 
ngx-bootstrap 5.6.0 or higher is required for Angular 9.  